### PR TITLE
Change permissions inside the package, detach

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ extract wisski-env.tar.gz
 
 start containers
 
-`$ docker-compose up`
+`$ docker-compose up -d`
 
 change permissions for drupal-website
 
-`$ sudo chown -R www-data:www-data drupal-website`
+`$ docker-compose run drupal chmod -R 0755 /var/www/html`
 
 go to your browser and type
 


### PR DESCRIPTION
Rather than changing file permissions from the host you should set permissions from the package. (This helps running the Docker package on a Windows host)